### PR TITLE
Use configured User model

### DIFF
--- a/squarelet_auth/__init__.py
+++ b/squarelet_auth/__init__.py
@@ -7,9 +7,6 @@ from squarelet_auth import settings
 
 
 def model_from_setting(setting_key):
-    """
-    Return the Organization model that is active in this project.
-    """
     setting_value = getattr(settings, setting_key)
     try:
         return django_apps.get_model(setting_value, require_ready=False)

--- a/squarelet_auth/__init__.py
+++ b/squarelet_auth/__init__.py
@@ -1,0 +1,24 @@
+# Django
+from django.apps import apps as django_apps
+from django.core.exceptions import ImproperlyConfigured
+
+# SquareletAuth
+from squarelet_auth import settings
+
+
+def model_from_setting(setting_key):
+    """
+    Return the Organization model that is active in this project.
+    """
+    setting_value = getattr(settings, setting_key)
+    try:
+        return django_apps.get_model(setting_value, require_ready=False)
+    except ValueError:
+        raise ImproperlyConfigured(
+            f"SQUARELET_{setting_key} must be of the form 'app_label.model_name'"
+        )
+    except LookupError:
+        raise ImproperlyConfigured(
+            f"SQUARELET_{setting_key} refers to model "
+            f"'{setting_value}' that has not been installed"
+        )

--- a/squarelet_auth/organizations/__init__.py
+++ b/squarelet_auth/organizations/__init__.py
@@ -1,23 +1,8 @@
-# Django
-from django.apps import apps as django_apps
-from django.core.exceptions import ImproperlyConfigured
-
-# SquareletAuth
-from squarelet_auth import settings
+from squarelet_auth import model_from_setting
 
 
 def get_organization_model():
     """
     Return the Organization model that is active in this project.
     """
-    try:
-        return django_apps.get_model(settings.ORGANIZATION_MODEL, require_ready=False)
-    except ValueError:
-        raise ImproperlyConfigured(
-            "SQUARELET_ORGANIZATION_MODEL must be of the form 'app_label.model_name'"
-        )
-    except LookupError:
-        raise ImproperlyConfigured(
-            f"SQUARELET_ORGANIZATION_MODEL refers to model "
-            f"'{settings.ORGANIZATION_MODEL}' that has not been installed"
-        )
+    return model_from_setting("ORGANIZATION_MODEL")

--- a/squarelet_auth/organizations/admin.py
+++ b/squarelet_auth/organizations/admin.py
@@ -1,12 +1,12 @@
 # Django
 from django.contrib import admin
-from django.contrib.auth import get_user_model
 from django.urls import reverse
 from django.utils.safestring import mark_safe
 
 # SquareletAuth
 from squarelet_auth import settings
 from squarelet_auth.organizations.models import Entitlement, Organization
+from squarelet_auth.users import get_user_model
 
 User = get_user_model()
 

--- a/squarelet_auth/pipeline.py
+++ b/squarelet_auth/pipeline.py
@@ -1,16 +1,13 @@
 """
 Custom pipeline steps for oAuth authentication
 """
-# Django
-from django.contrib.auth import get_user_model
-
 # Standard Library
 import logging
 
 # SquareletAuth
+from squarelet_auth.users import get_user_model
 from squarelet_auth.users.utils import squarelet_update_or_create
 
-User = get_user_model()
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +17,7 @@ logger = logging.getLogger(__name__)
 def associate_by_uuid(response, user=None, *args, **kwargs):
     """Associate current auth with a user with the same uuid in the DB."""
     # pylint: disable=unused-argument,keyword-arg-before-vararg
-
+    User = get_user_model()
     uuid = response.get("uuid")
     if uuid:
         try:

--- a/squarelet_auth/tasks.py
+++ b/squarelet_auth/tasks.py
@@ -2,7 +2,6 @@
 
 # Django
 from celery.task import task
-from django.contrib.auth import get_user_model
 
 # Standard Library
 import logging
@@ -16,6 +15,7 @@ from squarelet_auth.organizations import get_organization_model
 from squarelet_auth.organizations.utils import (
     squarelet_update_or_create as org_update_or_create,
 )
+from squarelet_auth.users import get_user_model
 from squarelet_auth.users.utils import (
     squarelet_update_or_create as user_update_or_create,
 )

--- a/squarelet_auth/users/__init__.py
+++ b/squarelet_auth/users/__init__.py
@@ -1,0 +1,5 @@
+from squarelet_auth import model_from_setting
+
+
+def get_user_model():
+    return model_from_setting("USER_MODEL")

--- a/squarelet_auth/users/utils.py
+++ b/squarelet_auth/users/utils.py
@@ -1,6 +1,5 @@
 # Django
 import django.dispatch
-from django.contrib.auth import get_user_model
 from django.db import transaction
 
 # Standard Library
@@ -13,6 +12,7 @@ from squarelet_auth.organizations.models import Membership
 from squarelet_auth.organizations.utils import (
     squarelet_update_or_create as organization_update_or_create,
 )
+from squarelet_auth.users import get_user_model
 
 User = get_user_model()
 Organization = get_organization_model()


### PR DESCRIPTION
## Description

This PR defines a `get_user_model` function, similar to `get_organization_model`, and uses it to retrieve User model configured in the app settings. This allows use of different user models for default authentication and Squarelet.

I have not tested this.